### PR TITLE
Added change I2C address feature

### DIFF
--- a/Adafruit_VL6180X.cpp
+++ b/Adafruit_VL6180X.cpp
@@ -43,11 +43,12 @@ Adafruit_VL6180X::Adafruit_VL6180X(void) {
 /*! 
     @brief  Initializes I2C interface, checks that VL6180X is found and resets chip.
     @param  theWire Optional pointer to I2C interface, &Wire is used by default
+    @param  i2caddr Optional adress on the module on i2c buse, VL6180X_DEFAULT_I2C_ADDR is used by default
     @returns True if chip found and initialized, False otherwise
 */
 /**************************************************************************/
-boolean Adafruit_VL6180X::begin(TwoWire *theWire) {
-  _i2caddr = VL6180X_DEFAULT_I2C_ADDR;
+boolean Adafruit_VL6180X::begin(TwoWire *theWire, uint8_t i2caddr) {
+  _i2caddr = i2caddr;
   if (! theWire) {
     _i2c = &Wire;
   } else {
@@ -244,6 +245,27 @@ float Adafruit_VL6180X::readLux(uint8_t gain) {
 
 
   return lux;
+}
+
+/**************************************************************************/
+/*! 
+    @brief  Initializes I2C interface, checks that VL6180X is found and resets chip.
+    @param  newAddr the value of new I2C adress to be used by VL6180X device
+*/
+/**************************************************************************/
+void Adafruit_VL6180X::changeAddress(uint8_t newAddr) {
+  write8(0x212, newAddr&0x7F);
+  _i2caddr = newAddr;
+}
+
+/**************************************************************************/
+/*! 
+    @brief gets current sensor address
+    @returns current sensor address
+*/
+/**************************************************************************/
+uint8_t Adafruit_VL6180X::getAddress() {
+  return _i2caddr;
 }
 
 /**************************************************************************/

--- a/Adafruit_VL6180X.h
+++ b/Adafruit_VL6180X.h
@@ -23,7 +23,7 @@
 
 //#define I2C_DEBUG
 
-#define VL6180X_DEFAULT_I2C_ADDR 0x29  ///< The fixed I2C addres
+#define VL6180X_DEFAULT_I2C_ADDR 0x29  ///< Default I2C addres
 
 ///! Device model identification number
 #define VL6180X_REG_IDENTIFICATION_MODEL_ID    0x000
@@ -78,10 +78,12 @@
 class Adafruit_VL6180X {
  public:
   Adafruit_VL6180X();
-  boolean begin(TwoWire *theWire = NULL);
+  boolean begin(TwoWire *theWire = NULL, uint8_t i2caddr = VL6180X_DEFAULT_I2C_ADDR);
   uint8_t readRange(void);
   float   readLux(uint8_t gain);
   uint8_t readRangeStatus(void);
+  void changeAddress(uint8_t newAddr);
+  uint8_t getAddress();
 
  private:
   void loadSettings(void);

--- a/examples/vl6180_changeAddress/vl6180_changeAddress.ino
+++ b/examples/vl6180_changeAddress/vl6180_changeAddress.ino
@@ -1,0 +1,90 @@
+#include <Wire.h>
+#include "Adafruit_VL6180X.h"
+
+Adafruit_VL6180X vl = Adafruit_VL6180X();
+
+uint8_t serialReadAddress() {
+  //Wait for data on serial port
+  while(!Serial.available()) {}
+  return (uint8_t) Serial.parseInt();
+}
+
+void setup() {
+  Serial.begin(115200);
+
+  // wait for serial port to open on native usb devices
+  while (!Serial) {
+    delay(1);
+  }
+  
+  Serial.println("Adafruit VL6180x adress change sample!");
+  Serial.print("Please enter current VL6180x. Default adress is ");
+  Serial.println(VL6180X_DEFAULT_I2C_ADDR);
+  uint8_t currentAddress = serialReadAddress();
+  Serial.print("Entered: ");
+  Serial.println(currentAddress);  
+  while (!vl.begin(NULL, currentAddress)) {
+    Serial.println("Unable to connect to VL6180x or the adress is wrong! Please enter again: ");
+    currentAddress = serialReadAddress();
+  }
+  
+  Serial.println("Please new adress of VL6180x:");
+  uint8_t newAdress = serialReadAddress();
+  Serial.print("Entered: ");
+  Serial.println(newAdress);  
+  if (newAdress != currentAddress) {
+    vl.changeAddress((uint8_t) newAdress);
+    if (!vl.begin(NULL, (uint8_t) newAdress)) {
+      Serial.println("Failed to find sensor using a new adress: ");
+    } else {
+      Serial.print("The adress is changed! New adress is ");
+    }
+    Serial.println(newAdress);
+  } else {
+    Serial.println("The address is the same, the change is skipped!");
+  }
+}
+
+void loop() {
+  float lux = vl.readLux(VL6180X_ALS_GAIN_5);
+
+  Serial.print("Lux: "); Serial.println(lux);
+  
+  uint8_t range = vl.readRange();
+  uint8_t status = vl.readRangeStatus();
+
+  if (status == VL6180X_ERROR_NONE) {
+    Serial.print("Range: "); Serial.println(range);
+  }
+
+  // Some error occurred, print it out!
+  
+  if  ((status >= VL6180X_ERROR_SYSERR_1) && (status <= VL6180X_ERROR_SYSERR_5)) {
+    Serial.println("System error");
+  }
+  else if (status == VL6180X_ERROR_ECEFAIL) {
+    Serial.println("ECE failure");
+  }
+  else if (status == VL6180X_ERROR_NOCONVERGE) {
+    Serial.println("No convergence");
+  }
+  else if (status == VL6180X_ERROR_RANGEIGNORE) {
+    Serial.println("Ignoring range");
+  }
+  else if (status == VL6180X_ERROR_SNR) {
+    Serial.println("Signal/Noise error");
+  }
+  else if (status == VL6180X_ERROR_RAWUFLOW) {
+    Serial.println("Raw reading underflow");
+  }
+  else if (status == VL6180X_ERROR_RAWOFLOW) {
+    Serial.println("Raw reading overflow");
+  }
+  else if (status == VL6180X_ERROR_RANGEUFLOW) {
+    Serial.println("Range reading underflow");
+  }
+  else if (status == VL6180X_ERROR_RANGEOFLOW) {
+    Serial.println("Range reading overflow");
+  }
+  delay(50);
+}

--- a/examples/vl6180_multiple/vl6180_multiple.ino
+++ b/examples/vl6180_multiple/vl6180_multiple.ino
@@ -1,0 +1,73 @@
+/**
+ * This example shows the usage of 3 VL6180X on the same I2c bus.
+ * Use vl6180_changeAddress example to change the address of the device
+ */
+#include <Wire.h>
+#include "Adafruit_VL6180X.h"
+
+//First devices uses default address, other devices use default + 1 and default + 2
+#define VL1_ADDRES VL6180X_DEFAULT_I2C_ADDR
+#define VL2_ADDRES VL6180X_DEFAULT_I2C_ADDR + 1
+#define VL3_ADDRES VL6180X_DEFAULT_I2C_ADDR + 2
+
+Adafruit_VL6180X vl1 = Adafruit_VL6180X();
+Adafruit_VL6180X vl2 = Adafruit_VL6180X();
+Adafruit_VL6180X vl3 = Adafruit_VL6180X();
+
+/**************************************************************************/
+/*! 
+    @brief  Initializes the sensor on the given address and prints Serial messages
+    @param  vl sensor handler to be initialized
+    @param  address i2c address of the sensor
+*/
+/**************************************************************************/
+void connect(Adafruit_VL6180X& vl, uint8_t address) {
+  Serial.print("Connecting to VL6180x using address: ");
+  Serial.println(address);
+  if (! vl.begin(NULL, address)) {
+    Serial.println("Failed to find sensor");
+    while (1);
+  }
+  Serial.println("Sensor found!");
+}
+
+/**************************************************************************/
+/*! 
+    @brief  Prints the range reported by sensor to Serial
+    @param  vl sensor handler to be initialized
+*/
+/**************************************************************************/
+void printRange(Adafruit_VL6180X& vl) {
+  
+  uint8_t range = vl.readRange();
+  uint8_t status = vl.readRangeStatus();
+
+  if (status == VL6180X_ERROR_NONE) {
+    Serial.print("Range of device on adress "); 
+    Serial.print(vl.getAddress()); 
+    Serial.print(": ");
+    Serial.println(range);
+  }
+}
+
+void setup() {
+  Serial.begin(115200);
+
+  // wait for serial port to open on native usb devices
+  while (!Serial) {
+    delay(1);
+  }
+
+  //Connect 3 sensors
+  connect(vl1, VL1_ADDRES);
+  connect(vl2, VL2_ADDRES);
+  connect(vl3, VL3_ADDRES);
+}
+
+void loop() {
+  //Print range reported by each sensor
+  printRange(vl1);  
+  printRange(vl2);  
+  printRange(vl3);  
+  delay(50);
+}

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit_VL6180X
-version=1.0.3
+version=1.0.4
 author=Adafruit
 maintainer=adafruit <support@adafruit.com>
 sentence=Sensor driver for VL6180X Time of Flight sensor


### PR DESCRIPTION
Hello @ladyada 

I am submitting a PR to be able to change I2C address of the sensor device. It provides same functionality as https://github.com/adafruit/Adafruit_VL6180X/pull/4, however it does not have merge conflict with current library codebase.

I have added the following into my commit:
- changeAddress function to change sensor address
- getAddress method to get current address of the sensor
- Vl6180_changeAddress example to demo how to change sensor address to the address provided by Serial interface
- vl6180_multiple example to prove that once the address is changed multiple devices could work on the same i2c bus
-  increased version in library.properties (not sure if it was needed, let me know if you'd like me to revert this change).

I have tested the changes on my 3 VL sensors and it works fine for me.

Let me know if any changes are suggested.

Thanks, K.