### PR TITLE
Add async interaction model

### DIFF
--- a/Adafruit_VL6180X.cpp
+++ b/Adafruit_VL6180X.cpp
@@ -1,5 +1,3 @@
-#include <utility>
-
 /*!
  * @file Adafruit_VL6180X.cpp
  *


### PR DESCRIPTION
* asyncReadRange
    Queue up a range read to be completed at some future point.
* asyncReadLux
    Queue up a lux read to be completed at some future point.
* asyncLoop
    Anchor the future point to a method call from loop()

The async model herein still relies on polling, but it does so while
surrendering execution back to the loop thread.  The developer is free
to provide any loop-compatible callback (i.e., no system interrupt
context limitations), though it's obvious to either flip a flag like
"ready" or add a schedule loop wherein the completion functions end up
scheduling another async read (this is what I do).

Without the async interaction, a lux reading blocks for ~100ms, and a
range reading blocks for ~50ms.  With async model, the interactions with
the library are typically sub-millisecond.

![example 50fps demo](https://user-images.githubusercontent.com/3454741/51658925-2df61680-1f5e-11e9-8d25-9e0d71ffccba.gif)
