### PR TITLE
Allow you to set a sensor Address like you can for vXL53..

### DIFF
--- a/Adafruit_VL6180X.cpp
+++ b/Adafruit_VL6180X.cpp
@@ -69,6 +69,31 @@ boolean Adafruit_VL6180X::begin(TwoWire *theWire) {
 
 /**************************************************************************/
 /*!
+    @brief  Sets the address of the device to a different address.
+   chip.
+    @param newAddr new I2C address for the device.
+    @returns True if write succeeded.
+*/
+/**************************************************************************/
+boolean Adafruit_VL6180X::setAddress(uint8_t newAddr) {
+  // BUGBUG - not sure if we detect errors or not...
+  // The register is mentioned in app notes.
+  write8(VL6180X_REG_SLAVE_DEVICE_ADDRESS, newAddr & 0x7F);
+  _i2caddr = newAddr;
+  return true;
+}
+
+/**************************************************************************/
+/*!
+    @brief  gets the address of the device
+   chip.
+    @returns the address
+*/
+/**************************************************************************/
+uint8_t Adafruit_VL6180X::getAddress(void) { return _i2caddr; }
+
+/**************************************************************************/
+/*!
     @brief  Load the settings for proximity/distance ranging
 */
 /**************************************************************************/

--- a/Adafruit_VL6180X.h
+++ b/Adafruit_VL6180X.h
@@ -51,6 +51,8 @@
 #define VL6180X_REG_RESULT_ALS_VAL 0x050
 ///! Ranging reading value
 #define VL6180X_REG_RESULT_RANGE_VAL 0x062
+///! I2C Slave Device Address
+#define VL6180X_REG_SLAVE_DEVICE_ADDRESS 0x212
 
 #define VL6180X_ALS_GAIN_1 0x06    ///< 1x gain
 #define VL6180X_ALS_GAIN_1_25 0x05 ///< 1.25x gain
@@ -78,6 +80,9 @@ class Adafruit_VL6180X {
 public:
   Adafruit_VL6180X();
   boolean begin(TwoWire *theWire = NULL);
+  boolean setAddress(uint8_t newAddr);
+  uint8_t getAddress(void);
+
   uint8_t readRange(void);
   float readLux(uint8_t gain);
   uint8_t readRangeStatus(void);

--- a/examples/vl6180x_triple/vl6180x_triple.ino
+++ b/examples/vl6180x_triple/vl6180x_triple.ino
@@ -1,0 +1,156 @@
+#include <Adafruit_VL6180X.h>
+
+// address we will assign if dual sensor is present
+#define LOX1_ADDRESS 0x30
+#define LOX2_ADDRESS 0x31
+#define LOX3_ADDRESS 0x32
+
+// set the pins to shutdown
+#define SHT_LOX1 7
+#define SHT_LOX2 6
+#define SHT_LOX3 5
+
+// objects for the VL6180X
+Adafruit_VL6180X lox1 = Adafruit_VL6180X();
+Adafruit_VL6180X lox2 = Adafruit_VL6180X();
+Adafruit_VL6180X lox3 = Adafruit_VL6180X();
+
+/*
+    Reset all sensors by setting all of their XSHUT pins low for delay(10), then set all XSHUT high to bring out of reset
+    Keep sensor #1 awake by keeping XSHUT pin high
+    Put all other sensors into shutdown by pulling XSHUT pins low
+    Initialize sensor #1 with lox.begin(new_i2c_address) Pick any number but 0x29 and it must be under 0x7F. Going with 0x30 to 0x3F is probably OK.
+    Keep sensor #1 awake, and now bring sensor #2 out of reset by setting its XSHUT pin high.
+    Initialize sensor #2 with lox.begin(new_i2c_address) Pick any number but 0x29 and whatever you set the first sensor to
+*/
+void setID() {
+  // all reset
+  digitalWrite(SHT_LOX1, LOW);
+  digitalWrite(SHT_LOX2, LOW);
+  digitalWrite(SHT_LOX3, LOW);
+  delay(10);
+
+  // all unreset
+  digitalWrite(SHT_LOX1, HIGH);
+  digitalWrite(SHT_LOX2, HIGH);
+  digitalWrite(SHT_LOX3, HIGH);
+  delay(10);
+
+  // activating LOX1 and reseting LOX2
+  digitalWrite(SHT_LOX1, HIGH);
+  digitalWrite(SHT_LOX2, LOW);
+  digitalWrite(SHT_LOX3, LOW);
+
+  // initing LOX1
+  if (!lox1.begin()) {
+    Serial.println(F("Failed to boot first VL6180X"));
+    while (1);
+  }
+  lox1.setAddress(LOX1_ADDRESS);
+  delay(10);
+
+  // activating LOX2
+  digitalWrite(SHT_LOX2, HIGH);
+  delay(10);
+
+  //initing LOX2
+  if (!lox2.begin()) {
+    Serial.println(F("Failed to boot second VL6180X"));
+    while (1);
+  }
+  lox2.setAddress(LOX2_ADDRESS);
+
+  // activating LOX3
+  digitalWrite(SHT_LOX3, HIGH);
+  delay(10);
+
+  //initing LOX3
+  if (!lox3.begin()) {
+    Serial.println(F("Failed to boot third VL6180X"));
+    while (1);
+  }
+  lox3.setAddress(LOX3_ADDRESS);
+}
+
+void readSensor(Adafruit_VL6180X &vl) {
+  Serial.print(" Addr: ");
+  Serial.print(vl.getAddress(), HEX);
+
+  float lux = vl.readLux(VL6180X_ALS_GAIN_5);
+  Serial.print(" Lux: "); Serial.print(lux);
+  uint8_t range = vl.readRange();
+  uint8_t status = vl.readRangeStatus();
+
+  if (status == VL6180X_ERROR_NONE) {
+    Serial.print(" Range: "); Serial.print(range);
+  }
+
+  // Some error occurred, print it out!
+
+  if  ((status >= VL6180X_ERROR_SYSERR_1) && (status <= VL6180X_ERROR_SYSERR_5)) {
+    Serial.print("(System error)");
+  }
+  else if (status == VL6180X_ERROR_ECEFAIL) {
+    Serial.print("(ECE failure)");
+  }
+  else if (status == VL6180X_ERROR_NOCONVERGE) {
+    Serial.print("(No convergence)");
+  }
+  else if (status == VL6180X_ERROR_RANGEIGNORE) {
+    Serial.print("(Ignoring range)");
+  }
+  else if (status == VL6180X_ERROR_SNR) {
+    Serial.print("Signal/Noise error");
+  }
+  else if (status == VL6180X_ERROR_RAWUFLOW) {
+    Serial.print("Raw reading underflow");
+  }
+  else if (status == VL6180X_ERROR_RAWOFLOW) {
+    Serial.print("Raw reading overflow");
+  }
+  else if (status == VL6180X_ERROR_RANGEUFLOW) {
+    Serial.print("Range reading underflow");
+  }
+  else if (status == VL6180X_ERROR_RANGEOFLOW) {
+    Serial.print("Range reading overflow");
+  }
+}
+
+void read_sensors() {
+  readSensor(lox1);
+  readSensor(lox2);
+  readSensor(lox3);
+  Serial.println();
+}
+
+void setup() {
+  Serial.begin(115200);
+
+  // wait until serial port opens for native USB devices
+  while (! Serial) {
+    delay(1);
+  }
+
+  pinMode(SHT_LOX1, OUTPUT);
+  pinMode(SHT_LOX2, OUTPUT);
+  pinMode(SHT_LOX3, OUTPUT);
+
+  Serial.println("Shutdown pins inited...");
+
+  digitalWrite(SHT_LOX1, LOW);
+  digitalWrite(SHT_LOX2, LOW);
+  digitalWrite(SHT_LOX3, LOW);
+
+  Serial.println("All in reset mode...(pins are low)");
+
+
+  Serial.println("Starting...");
+  setID();
+
+}
+
+void loop() {
+
+  read_sensors();
+  delay(100);
+}

--- a/keywords.txt
+++ b/keywords.txt
@@ -1,0 +1,7 @@
+Adafruit_VL6180X	KEYWORD1
+begin	KEYWORD2
+setAddress	KEYWORD2
+getAddress	KEYWORD2
+readRange	KEYWORD2
+readLux	KEYWORD2
+readRangeStatus	KEYWORD2


### PR DESCRIPTION
As I mentioned on the forum thread: 
https://forums.adafruit.com/viewtopic.php?f=8&t=167687

I wondered if these sensors allow you to set the I2C slave address, I saw you could from the Pololu library plus verified it in the ST Applications notes. 

However for at least this pass,  I only added the setAddress, and also added a getAddress to retrieve it later if desired.

I did not add it to begin as that would make the begin not be compatible with existing code.

Added a keywords.txt file

Added a three sensor test like the dual for the other one...
Nothing special but appears to work.


