### PR TITLE
Asynchronous read ranges

### DIFF
--- a/Adafruit_VL6180X.cpp
+++ b/Adafruit_VL6180X.cpp
@@ -217,41 +217,41 @@ boolean Adafruit_VL6180X::startRange(void) {
 /**************************************************************************/
 
 boolean Adafruit_VL6180X::isRangeComplete(void) {
-  
+
   // Poll until bit 2 is set
   if ((read8(VL6180X_REG_RESULT_INTERRUPT_STATUS_GPIO) & 0x04))
     return true;
 
   return false;
-}  
+}
 
 /**************************************************************************/
 /*!
     @brief  Wait until Range completed
-    @return true if range completed. 
+    @return true if range completed.
 */
 /**************************************************************************/
 
 boolean Adafruit_VL6180X::waitRangeComplete(void) {
-  
+
   // Poll until bit 2 is set
   while (!(read8(VL6180X_REG_RESULT_INTERRUPT_STATUS_GPIO) & 0x04))
     ;
 
   return true;
-}  
+}
 
 /**************************************************************************/
 /*!
     @brief  Return results of read reqyest also clears out the interrupt
     Be sure to check the return of {@link readRangeStatus} to before using
     the return value!
-    @return if range started. 
+    @return if range started.
 */
 /**************************************************************************/
 
 uint8_t Adafruit_VL6180X::readRangeResult(void) {
-  
+
   // read range in mm
   uint8_t range = read8(VL6180X_REG_RESULT_RANGE_VAL);
 

--- a/Adafruit_VL6180X.cpp
+++ b/Adafruit_VL6180X.cpp
@@ -189,6 +189,80 @@ uint8_t Adafruit_VL6180X::readRange(void) {
 
 /**************************************************************************/
 /*!
+    @brief  start Single shot ranging. The caller of this should have code
+    that waits until the read completes, by either calling
+    {@link waitRangeComplete} or calling {@link isRangeComplete} until it
+    returns true.  And then the code should call {@link readRangeResult}
+    to retrieve the range value and clear out the internal status.
+    @return true if range completed.
+*/
+/**************************************************************************/
+
+boolean Adafruit_VL6180X::startRange(void) {
+  // wait for device to be ready for range measurement
+  while (!(read8(VL6180X_REG_RESULT_RANGE_STATUS) & 0x01))
+    ;
+
+  // Start a range measurement
+  write8(VL6180X_REG_SYSRANGE_START, 0x01);
+
+  return true;
+}
+
+/**************************************************************************/
+/*!
+    @brief  Check to see if the range command completed.
+    @return true if range completed.
+*/
+/**************************************************************************/
+
+boolean Adafruit_VL6180X::isRangeComplete(void) {
+  
+  // Poll until bit 2 is set
+  if ((read8(VL6180X_REG_RESULT_INTERRUPT_STATUS_GPIO) & 0x04))
+    return true;
+
+  return false;
+}  
+
+/**************************************************************************/
+/*!
+    @brief  Wait until Range completed
+    @return true if range completed. 
+*/
+/**************************************************************************/
+
+boolean Adafruit_VL6180X::waitRangeComplete(void) {
+  
+  // Poll until bit 2 is set
+  while (!(read8(VL6180X_REG_RESULT_INTERRUPT_STATUS_GPIO) & 0x04))
+    ;
+
+  return true;
+}  
+
+/**************************************************************************/
+/*!
+    @brief  Return results of read reqyest also clears out the interrupt
+    Be sure to check the return of {@link readRangeStatus} to before using
+    the return value!
+    @return if range started. 
+*/
+/**************************************************************************/
+
+uint8_t Adafruit_VL6180X::readRangeResult(void) {
+  
+  // read range in mm
+  uint8_t range = read8(VL6180X_REG_RESULT_RANGE_VAL);
+
+  // clear interrupt
+  write8(VL6180X_REG_SYSTEM_INTERRUPT_CLEAR, 0x07);
+
+  return range;
+}
+
+/**************************************************************************/
+/*!
     @brief  Request ranging success/error message (retreive after ranging)
     @returns One of possible VL6180X_ERROR_* values
 */

--- a/Adafruit_VL6180X.h
+++ b/Adafruit_VL6180X.h
@@ -87,6 +87,11 @@ public:
   float readLux(uint8_t gain);
   uint8_t readRangeStatus(void);
 
+  boolean startRange(void);
+  boolean isRangeComplete(void);
+  boolean waitRangeComplete(void);
+  uint8_t readRangeResult(void);
+
 private:
   void loadSettings(void);
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -5,3 +5,7 @@ getAddress	KEYWORD2
 readRange	KEYWORD2
 readLux	KEYWORD2
 readRangeStatus	KEYWORD2
+startRange	KEYWORD2
+isRangeComplete	KEYWORD2
+waitRangeComplete	KEYWORD2
+readRangeResult	KEYWORD2


### PR DESCRIPTION
Experimenting with adding appis that allow you to instead of do a readRange, which starts it up and waits for it to complete, instead add a set of APIs that allow me
to startup a range(Adafruit_VL6180X::startRange), check to see if it is done (isRangeComplete), wait for it to complete (waitRangeComplete)

and when completed ou call readRangeResult, which returns the value and dlears out the system interrupt.

I also updated the triple sensor test program, with real simple serial input to change modes
d - back to the earlier output with more detailed output.
t - timed output for reading each of the three servos one at a time
a - async timed start all three wait for all three to complete and grab values.

Keywords.txt also updated to show the new methods.

Not sure if you wish to review these names before merging.  Also may also look at maybe looking at some other functionality...   Which could then be added to this PULL or could be done on feature by feature...

Hopefully I did not do any doxygen... or clang issues. but will watch to see as it is verified.

