### PR TITLE
Can't use VL6180X without reset if the chip's I2C address was changed earlier by another sketch

### DIFF
--- a/Adafruit_VL6180X.cpp
+++ b/Adafruit_VL6180X.cpp
@@ -39,7 +39,7 @@
     @brief  Instantiates a new VL6180X class
 */
 /**************************************************************************/
-Adafruit_VL6180X::Adafruit_VL6180X(void) {}
+Adafruit_VL6180X::Adafruit_VL6180X(uint8_t i2caddr) : _i2caddr(i2caddr) {}
 
 /**************************************************************************/
 /*!
@@ -50,7 +50,6 @@ Adafruit_VL6180X::Adafruit_VL6180X(void) {}
 */
 /**************************************************************************/
 boolean Adafruit_VL6180X::begin(TwoWire *theWire) {
-  _i2caddr = VL6180X_DEFAULT_I2C_ADDR;
   if (!theWire) {
     _i2c = &Wire;
   } else {

--- a/Adafruit_VL6180X.cpp
+++ b/Adafruit_VL6180X.cpp
@@ -37,6 +37,8 @@
 /**************************************************************************/
 /*!
     @brief  Instantiates a new VL6180X class
+    @param  i2caddr Optional initial i2c address of the chip,
+   VL6180X_DEFAULT_I2C_ADDR is used by default
 */
 /**************************************************************************/
 Adafruit_VL6180X::Adafruit_VL6180X(uint8_t i2caddr) : _i2caddr(i2caddr) {}

--- a/Adafruit_VL6180X.h
+++ b/Adafruit_VL6180X.h
@@ -78,7 +78,7 @@
 ///! Class for managing connection and state to a VL6180X sensor
 class Adafruit_VL6180X {
 public:
-  Adafruit_VL6180X();
+  Adafruit_VL6180X(uint8_t i2caddr = VL6180X_DEFAULT_I2C_ADDR);
   boolean begin(TwoWire *theWire = NULL);
   boolean setAddress(uint8_t newAddr);
   uint8_t getAddress(void);


### PR DESCRIPTION
**Problem:** The library provides no way to use the chip without reset if the I2C address of the chip was changed earlier.
The example [vl6180x_triple.ino](https://github.com/adafruit/Adafruit_VL6180X/blob/master/examples/vl6180x_triple/vl6180x_triple.ino) uses 3 chips, but it requires to have 3 extra wires to the shutdown pins in order to reset the chip.
For practical usage, it is much more convenient to perform the address setup procedure once using the separate sketch and, later, just init the chip with the required address without performing a reset.

However, it is not possible now as ``begin`` functions hardcodes the initial address to ``VL6180X_DEFAULT_I2C_ADDR``
```
boolean Adafruit_VL6180X::begin(TwoWire *theWire) {
  _i2caddr = VL6180X_DEFAULT_I2C_ADDR;
```
As a result, there is no way to interact with the chip having the address changed earlier without performing a chip reset and changing the address every time.

The change I suggest moves the ``_i2caddr`` initialization to the constructor and adds an optional constructor parameter to change the address.

It would make it possible to use the library this way for the chip which I2C address was changed to 0x30 earlier:
```
#define LOX1_ADDRESS 0x30
Adafruit_VL6180X lox1 = Adafruit_VL6180X(LOX1_ADDRESS);
if (!lox1.begin()) {
    Serial.println(F("Failed to boot second VL6180X"));
    while (1);
}
```
