### PR TITLE
Tweak memory alloc and cleanup AND renable fresh_out_of_reset check

### DIFF
--- a/Adafruit_VL6180X.h
+++ b/Adafruit_VL6180X.h
@@ -77,6 +77,7 @@
 class Adafruit_VL6180X {
 public:
   Adafruit_VL6180X(uint8_t i2caddr = VL6180X_DEFAULT_I2C_ADDR);
+  ~Adafruit_VL6180X();
   boolean begin(TwoWire *theWire = &Wire);
   boolean setAddress(uint8_t newAddr);
   uint8_t getAddress(void);

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit_VL6180X
-version=1.3.0
+version=1.3.1
 author=Adafruit
 maintainer=adafruit <support@adafruit.com>
 sentence=Sensor driver for VL6180X Time of Flight sensor


### PR DESCRIPTION
This is nominally for #15, although the issue there is confusing and so far has not been repeatable. However, app note **[AN4545 VL6180X basic ranging application note](https://www.st.com/resource/en/application_note/an4545-vl6180x-basic-ranging-application-note-stmicroelectronics.pdf)** does suggest (optional) checking the fresh out of reset bit as part of sensor initialization.
![image](https://user-images.githubusercontent.com/8755041/130701906-291a5b45-0237-4c7b-946f-75c057f334db.png)

This PR removes the commented out conditional, alters it slightly, and puts the register reset (set back 0) in there. Seems OK to just have this in place?

PR also includes minor memory allocation tweaks.

Tested with Qt PY.
```cpp
#include "Adafruit_VL6180X.h"

Adafruit_VL6180X vl = Adafruit_VL6180X();

void setup() {
  Serial.begin(9600);
  while (!Serial) delay(1);
  
  Serial.println("Adafruit VL6180x multi begin() test!");
}

void loop() {
  if (! vl.begin()) {
    Serial.println("Failed to find sensor");
    while (1);
  }
  
  float lux = vl.readLux(VL6180X_ALS_GAIN_5);

  Serial.print("Lux: "); Serial.println(lux);
  
  uint8_t range = vl.readRange();
  uint8_t status = vl.readRangeStatus();

  if (status == VL6180X_ERROR_NONE) {
    Serial.print("Range: "); Serial.println(range);
  }

  // Some error occurred, print it out!
  
  if  ((status >= VL6180X_ERROR_SYSERR_1) && (status <= VL6180X_ERROR_SYSERR_5)) {
    Serial.println("System error");
  }
  else if (status == VL6180X_ERROR_ECEFAIL) {
    Serial.println("ECE failure");
  }
  else if (status == VL6180X_ERROR_NOCONVERGE) {
    Serial.println("No convergence");
  }
  else if (status == VL6180X_ERROR_RANGEIGNORE) {
    Serial.println("Ignoring range");
  }
  else if (status == VL6180X_ERROR_SNR) {
    Serial.println("Signal/Noise error");
  }
  else if (status == VL6180X_ERROR_RAWUFLOW) {
    Serial.println("Raw reading underflow");
  }
  else if (status == VL6180X_ERROR_RAWOFLOW) {
    Serial.println("Raw reading overflow");
  }
  else if (status == VL6180X_ERROR_RANGEUFLOW) {
    Serial.println("Range reading underflow");
  }
  else if (status == VL6180X_ERROR_RANGEOFLOW) {
    Serial.println("Range reading overflow");
  }
  
  delay(1000);
}
```

![Screenshot from 2021-08-24 16-11-27](https://user-images.githubusercontent.com/8755041/130702134-88f6165c-93c8-425b-85e8-5bccd94a8992.png)

