### PR TITLE
Fix the ALS intergration period in init sequence

### DIFF
--- a/Adafruit_VL6180X.cpp
+++ b/Adafruit_VL6180X.cpp
@@ -162,7 +162,7 @@ void Adafruit_VL6180X::loadSettings(void) {
   write8(0x0031, 0xFF); // sets the # of range measurements after
                         // which auto calibration of system is
                         // performed
-  write8(0x0040, 0x63); // Set ALS integration time to 100ms
+  write8(0x0041, 0x63); // Set ALS integration time to 100ms
   write8(0x002e, 0x01); // perform a single temperature calibration
                         // of the ranging sensor
 


### PR DESCRIPTION
According to AN4545, the integration period for ALS measurements (16-bit register 0x40) is set to 100 ms, which corresponds to register value 0x0063. Since 16-bit registers are big-endian, the low byte must be written to 0x41 as specified in the init sequence in AN4545:
```
WriteByte(0x0041, 0x63); // Set ALS integration time to 100ms
```
The high byte at address 0x40 is already 0 after a reset.

This bug doesn't lead to problems because  `Adafruit_VL6180X::readLux` overwrites the register with the right value before the measurement is started.