### PR TITLE
add capability to set offset and read ID registers

### DIFF
--- a/Adafruit_VL6180X.cpp
+++ b/Adafruit_VL6180X.cpp
@@ -424,7 +424,6 @@ void Adafruit_VL6180X::getID(uint8_t *id_ptr) {
   id_ptr[4] = read8(VL6180X_REG_IDENTIFICATION_MODEL_ID + 4);
   id_ptr[6] = read8(VL6180X_REG_IDENTIFICATION_MODEL_ID + 6);
   id_ptr[7] = read8(VL6180X_REG_IDENTIFICATION_MODEL_ID + 7);
-
 }
 
 /**************************************************************************/

--- a/Adafruit_VL6180X.cpp
+++ b/Adafruit_VL6180X.cpp
@@ -396,6 +396,44 @@ float Adafruit_VL6180X::readLux(uint8_t gain) {
   return lux;
 }
 
+
+
+/**************************************************************************/
+/*!
+    @brief  Single shot lux measurement
+    @param  offset Offset setting
+*/
+/**************************************************************************/
+
+void Adafruit_VL6180X::setOffset(uint8_t offset) {
+  //write the offset
+  write8(VL6180X_REG_SYSRANGE_PART_TO_PART_RANGE_OFFSET, offset);
+}
+
+
+/**************************************************************************/
+/*!
+    @brief  Single shot lux measurement
+    @param  id_ptr Pointer to array of id bytes
+*/
+/**************************************************************************/
+
+void Adafruit_VL6180X::getID(uint8_t * id_ptr) {
+  uint8_t id[8];
+
+  id[0] = read8(VL6180X_REG_IDENTIFICATION_MODEL_ID + 0);
+  id[1] = read8(VL6180X_REG_IDENTIFICATION_MODEL_ID + 1);
+  id[2] = read8(VL6180X_REG_IDENTIFICATION_MODEL_ID + 2);
+  id[3] = read8(VL6180X_REG_IDENTIFICATION_MODEL_ID + 3);
+  id[4] = read8(VL6180X_REG_IDENTIFICATION_MODEL_ID + 4);
+  id[5] = read8(VL6180X_REG_IDENTIFICATION_MODEL_ID + 5);
+  id[6] = read8(VL6180X_REG_IDENTIFICATION_MODEL_ID + 6);
+  id[7] = read8(VL6180X_REG_IDENTIFICATION_MODEL_ID + 7);
+
+  id_ptr = &id[0];
+}
+
+
 /**************************************************************************/
 /*!
     @brief  I2C low level interfacing

--- a/Adafruit_VL6180X.cpp
+++ b/Adafruit_VL6180X.cpp
@@ -400,7 +400,7 @@ float Adafruit_VL6180X::readLux(uint8_t gain) {
 
 /**************************************************************************/
 /*!
-    @brief  Single shot lux measurement
+    @brief  Set the offset
     @param  offset Offset setting
 */
 /**************************************************************************/
@@ -413,7 +413,7 @@ void Adafruit_VL6180X::setOffset(uint8_t offset) {
 
 /**************************************************************************/
 /*!
-    @brief  Single shot lux measurement
+    @brief  Get the 8 bytes of id
     @param  id_ptr Pointer to array of id bytes
 */
 /**************************************************************************/

--- a/Adafruit_VL6180X.cpp
+++ b/Adafruit_VL6180X.cpp
@@ -396,8 +396,6 @@ float Adafruit_VL6180X::readLux(uint8_t gain) {
   return lux;
 }
 
-
-
 /**************************************************************************/
 /*!
     @brief  Set the offset
@@ -406,33 +404,28 @@ float Adafruit_VL6180X::readLux(uint8_t gain) {
 /**************************************************************************/
 
 void Adafruit_VL6180X::setOffset(uint8_t offset) {
-  //write the offset
+  // write the offset
   write8(VL6180X_REG_SYSRANGE_PART_TO_PART_RANGE_OFFSET, offset);
 }
 
-
 /**************************************************************************/
 /*!
-    @brief  Get the 8 bytes of id
+    @brief  Get the 7 bytes of id
     @param  id_ptr Pointer to array of id bytes
 */
 /**************************************************************************/
 
-void Adafruit_VL6180X::getID(uint8_t * id_ptr) {
-  uint8_t id[8];
+void Adafruit_VL6180X::getID(uint8_t *id_ptr) {
 
-  id[0] = read8(VL6180X_REG_IDENTIFICATION_MODEL_ID + 0);
-  id[1] = read8(VL6180X_REG_IDENTIFICATION_MODEL_ID + 1);
-  id[2] = read8(VL6180X_REG_IDENTIFICATION_MODEL_ID + 2);
-  id[3] = read8(VL6180X_REG_IDENTIFICATION_MODEL_ID + 3);
-  id[4] = read8(VL6180X_REG_IDENTIFICATION_MODEL_ID + 4);
-  id[5] = read8(VL6180X_REG_IDENTIFICATION_MODEL_ID + 5);
-  id[6] = read8(VL6180X_REG_IDENTIFICATION_MODEL_ID + 6);
-  id[7] = read8(VL6180X_REG_IDENTIFICATION_MODEL_ID + 7);
+  id_ptr[0] = read8(VL6180X_REG_IDENTIFICATION_MODEL_ID + 0);
+  id_ptr[1] = read8(VL6180X_REG_IDENTIFICATION_MODEL_ID + 1);
+  id_ptr[2] = read8(VL6180X_REG_IDENTIFICATION_MODEL_ID + 2);
+  id_ptr[3] = read8(VL6180X_REG_IDENTIFICATION_MODEL_ID + 3);
+  id_ptr[4] = read8(VL6180X_REG_IDENTIFICATION_MODEL_ID + 4);
+  id_ptr[6] = read8(VL6180X_REG_IDENTIFICATION_MODEL_ID + 6);
+  id_ptr[7] = read8(VL6180X_REG_IDENTIFICATION_MODEL_ID + 7);
 
-  id_ptr = &id[0];
 }
-
 
 /**************************************************************************/
 /*!

--- a/Adafruit_VL6180X.h
+++ b/Adafruit_VL6180X.h
@@ -33,6 +33,8 @@
 #define VL6180X_REG_SYSTEM_FRESH_OUT_OF_RESET 0x016
 ///! Trigger Ranging
 #define VL6180X_REG_SYSRANGE_START 0x018
+///! Part to part range offset
+#define VL6180X_REG_SYSRANGE_PART_TO_PART_RANGE_OFFSET 0x024
 ///! Trigger Lux Reading
 #define VL6180X_REG_SYSALS_START 0x038
 ///! Lux reading gain
@@ -94,6 +96,9 @@ public:
   void startRangeContinuous(uint16_t period_ms = 50);
   void stopRangeContinuous(void);
   // readRangeResult and isRangeComplete apply here is well
+
+  void setOffset(uint8_t offset);
+  void getID(uint8_t * id_ptr);
 
 private:
   Adafruit_I2CDevice *i2c_dev = NULL; ///< Pointer to I2C bus interface

--- a/Adafruit_VL6180X.h
+++ b/Adafruit_VL6180X.h
@@ -98,7 +98,7 @@ public:
   // readRangeResult and isRangeComplete apply here is well
 
   void setOffset(uint8_t offset);
-  void getID(uint8_t * id_ptr);
+  void getID(uint8_t *id_ptr);
 
 private:
   Adafruit_I2CDevice *i2c_dev = NULL; ///< Pointer to I2C bus interface


### PR DESCRIPTION
Hi,

I'm using the VL6180X and needed to do two things which were not implemented in the library:

1 - change the offset register to 'calibrate' the range
2 - read the ID bytes

These have been implemented and I've tested them to be functional.

I've never done a pull request so be gentle!

Thanks


