### PR TITLE
Fix for SYSALS__INTEGRATION_PERIOD register typo

### DIFF
--- a/Adafruit_VL6180X.cpp
+++ b/Adafruit_VL6180X.cpp
@@ -162,7 +162,7 @@ void Adafruit_VL6180X::loadSettings(void) {
   write8(0x0031, 0xFF); // sets the # of range measurements after
                         // which auto calibration of system is
                         // performed
-  write8(0x0041, 0x63); // Set ALS integration time to 100ms
+  write8(0x0040, 0x63); // Set ALS integration time to 100ms
   write8(0x002e, 0x01); // perform a single temperature calibration
                         // of the ranging sensor
 


### PR DESCRIPTION
This fixes a typo in the VL6180 Arduino library. 

The SYSALS__INTEGRATION_PERIOD register is 0x0040, not 0x0041

the address is on p.67 of datasheet

correct register is used in the Adafruit CircuitPython library: https://github.com/adafruit/Adafruit_CircuitPython_VL6180X/blob/8b7a343942667d6fd3b72e80327cc0af4847e3ac/adafruit_vl6180x.py#L364

