### PR TITLE
Update maintainer value to `Adafruit <info@adafruit.com>` in `library.properties`

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,7 +1,7 @@
 name=Adafruit_VL6180X
 version=1.4.3
 author=Adafruit
-maintainer=Adafruit <support@adafruit.com>
+maintainer=Adafruit <info@adafruit.com>
 sentence=Sensor driver for VL6180X Time of Flight sensor
 paragraph=Sensor driver for VL6180X Time of Flight sensor
 category=Sensors

--- a/library.properties
+++ b/library.properties
@@ -1,7 +1,7 @@
 name=Adafruit_VL6180X
 version=1.4.3
 author=Adafruit
-maintainer=adafruit <support@adafruit.com>
+maintainer=Adafruit <support@adafruit.com>
 sentence=Sensor driver for VL6180X Time of Flight sensor
 paragraph=Sensor driver for VL6180X Time of Flight sensor
 category=Sensors


### PR DESCRIPTION
- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  Modified the `library.properties` entry such that the `maintainer` field value is `Adafruit <info@adafruit.com>` instead of `adafruit <support@adafruit.com>`. This syntax is used for the maintainer value in other Adafruit libraries, such as [Adafruit_ADXL345](https://github.com/adafruit/Adafruit_ADXL345/blob/8e799d73d8eca7e6c00e74f7cecd325f6d88e113/library.properties#L4) and [Adafruit_TestBed](https://github.com/adafruit/Adafruit_TestBed/blob/0de33c28046a0cbc7e0661460329300572950a04/library.properties#L4)

- **Describe any known limitations with your change.**  N/A

- **Please run any tests or examples that can exercise your modified code.**  N/A
